### PR TITLE
Bugfix: Elevator did not switch direction of travel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,5 +35,5 @@
 - Elevator has new state of open to load and unload passengers.
 - Elevator has capacity limits.
 
-## 0.3.32 (20 October 2024)
+## 0.3.3 (20 October 2024)
 - Correct bug in which elevator fails to turn around.

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,2 @@
 - Error handling, replace existing errors with custom.
+- Pick up people in direction of travel

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 app.py
 Samuel Koller
 Created: 15 October 2024
-Updated: 19 October 2024
+Updated: 20 October 2024
 
 Main file for the Bluestaq Elevator Application. Houses the Flask server and relevant endpoints.
 
@@ -10,7 +10,7 @@ Functions:
     health_check(): A route to check if the service is running.
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 
 import logging

--- a/src/classes/elevator.py
+++ b/src/classes/elevator.py
@@ -2,7 +2,7 @@
 elevator.py
 Samuel Koller
 Created: 17 October 2024
-Updated: 19 October 2024
+Updated: 20 October 2024
 
 Class for the Elevator object, which tracks the state an contents of the elevator.
 """
@@ -90,12 +90,16 @@ class Elevator:
                     self.open()
         else:
             self.status = Status.IDLE
+        if self.current_floor == 1:
+            self.direction_up = True
+        elif self.current_floor == TOP_FLOOR:
+            self.direction_up = False
 
     def open(self) -> None:
         """Opens the doors."""
         self.status = Status.OPEN
-        self.load()
         self.stop_queue.pop(0)
+        self.load()
 
     def load(self) -> None:
         """

--- a/tests/classes/test_elevator.py
+++ b/tests/classes/test_elevator.py
@@ -20,6 +20,17 @@ def test_elevator_add_stop():
     assert test_elevator.stop_queue == [2]
 
 
+def test_elevator_switch_direction_at_limit():
+    """
+    - Tests the ability to change the direction of travel if the elevator has reached a limit.
+    """
+    test_elevator = Elevator()
+    test_elevator.current_floor = 20
+    test_elevator.update()
+
+    assert test_elevator.direction_up is False
+
+
 def test_elevator_add_ignored_stops():
     """
     - Tests the ability of the elevator to not add the current floor to the stop queue.


### PR DESCRIPTION
# Version 0.3.2 -> 0.3.3

## Description:

Elevator switches direction at top and bottom.

## Changes:
- Correct bug in which elevator fails to turn around.