### PR TITLE
Bugfix: Requeue floors that filled capacity and left persons behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,6 @@
 ## 0.4.0 (21 October 2024)
 - Redesign the elevator to have three queues, up, down, and priority.
 - Add detail to endpoint responses.
+
+## 0.4.1 (22 October 2024)
+- Correct bug in which when an elevator was filled to capacity and persons were left at the current floor, the floor was removed from the queue.

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 app.py
 Samuel Koller
 Created: 15 October 2024
-Updated: 20 October 2024
+Updated: 22 October 2024
 
 Main file for the Bluestaq Elevator Application. Houses the Flask server and relevant endpoints.
 
@@ -13,7 +13,7 @@ Functions:
     step(): A route to add persons to the system.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 import logging

--- a/src/classes/elevator.py
+++ b/src/classes/elevator.py
@@ -2,7 +2,7 @@
 elevator.py
 Samuel Koller
 Created: 17 October 2024
-Updated: 21 October 2024
+Updated: 22 October 2024
 
 Class for the Elevator object, which tracks the state an contents of the elevator.
 """
@@ -202,6 +202,17 @@ class Elevator:
             self.move_up()
         else:
             self.move_down()
+
+        previous_floor: int = self.current_floor - (1 if up else -1)
+        # ? If people were unable to board, requeue the previous floor.
+        if self.persons.get(previous_floor, []):
+            # pylint: disable=expression-not-assigned
+            [
+                self.add_person_stop(person)
+                for person in self.persons.get(previous_floor, [])
+            ]
+            # pylint: enable=expression-not-assigned
+
         # ? Skip the 13th floor by moving again.
         if self.current_floor == 13:
             self.move(up)
@@ -311,7 +322,12 @@ class Elevator:
         # ? If the added person is on the floor of the current elevator and it is open, load immediately.
         if person.location == self.current_floor and self.is_open:
             self.open()
-        elif person.location < person.destination:
+        else:
+            self.add_person_stop(person)
+
+    def add_person_stop(self, person: Person) -> None:
+        """Adds the person's floor to the correct queue."""
+        if person.location < person.destination:
             self.add_up_stop(person.location)
         else:
             self.add_down_stop(person.location)

--- a/tests/classes/test_elevator.py
+++ b/tests/classes/test_elevator.py
@@ -2,7 +2,7 @@
 test_elevator.py
 Samuel Koller
 Created: 17 October 2024
-Updated: 21 October 2024
+Updated: 22 October 2024
 
 Test Suite for the Elevator class.
 """
@@ -336,9 +336,11 @@ def test_elevator_stop_adding_at_capacity():
     test_person_2 = Person(**{"origin": 1, "destination": 10})
     test_elevator.add_person(test_person_1)
     test_elevator.add_person(test_person_2)
+    test_elevator.update()
 
     assert len(test_elevator.persons.get("elevator")) == 1
     assert len(test_elevator.persons.get(1)) == 1
+    assert test_elevator.up_queue == [10, 1]
 
 
 def test_elevator_switch_direction_at_limit():


### PR DESCRIPTION
# Version 0.4.0 -> 0.4.1

## Description:

Requeue floors that filled capacity and left persons behind

## Changes:
- Correct bug in which when an elevator was filled to capacity and persons were left at the current floor, the floor was removed from the queue.