### PR TITLE
Bugfix: Floor Queuing after Priority Stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,3 +80,8 @@
 ## 1.0.0 (22 October 2024)
 
 - Minimum viable product, with up-to-date documentation.
+
+## 1.0.1 (23 October 2024)
+
+- Correct bug in which floors could be queued in the wrong direction following a priority stop completion.
+- Extra validation for button presses.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Examples:
   - Description: Success
   - Message: Submitted person invalid, details show invalid person.
 
+# Safety Features
+
+The elevator has multiple safety features built in. The first safety feature is capacity limits, there are limits to the weight and number of individuals the elevator may carry, which are defined in `constants.py`.
+
+Additionally, the elevator has the ability to make a priority stop in the case of an emergency, to do this the close and a floor number button are pressed at the same time. When this occurs, the standard queue is deleted until the priority stop(s) are made. Once the priority stop queue is empty, all persons in the elevator system requeue their requests.
+
 # Contributing
 
 When contributing please continue to use the consistency standards set in place. To do this, ensure you have installed the development requirements. If so, run these commands (or run `. precommit.sh`):

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,3 @@
-- Bug: If a person is going down to floor 7 from floor 10 and floor 1 is prioritized, floor 7 stays in down queue, so after reaching floor 1, the elevator goes up to floor 8, then back down to floor 7.
-  - Fix: if a stop is added to priority queue, clear other queues. Then when the priority queue is emptied, requeue everything manually.
 - Improve algorithm efficiencies.
 - Create an endpoint to randomly generate a simulation, meaning a set number of steps and random persons being created during random steps.
 - Implement a sound for the current direction of the elevator at the end of the step endpoint. This would play a ding if the elevator is going up, two dings if the elevator is going down, and no sound if the elevator is open/idle.

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 app.py
 Samuel Koller
 Created: 15 October 2024
-Updated: 22 October 2024
+Updated: 23 October 2024
 
 Main file for the Bluestaq Elevator Problem. Houses the Flask server and relevant endpoints.
 
@@ -13,7 +13,7 @@ Functions:
     step(): A route to add persons to the system.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 import logging

--- a/src/classes/elevator.py
+++ b/src/classes/elevator.py
@@ -74,6 +74,7 @@ class Elevator:
 
         self.process_button(source, button, priority)
 
+    # pylint: disable=too-many-branches
     def process_button(self, source, button, priority: bool) -> None:
         """
         Ensures button combination is valid and takes the appropriate action.
@@ -107,6 +108,8 @@ class Elevator:
                 self.add_stop(button, priority)
             else:
                 raise InvalidButton()
+
+    # pylint: enable=too-many-branches
 
     def update(self) -> None:
         """Determines what the next action for the elevator is."""

--- a/src/classes/elevator.py
+++ b/src/classes/elevator.py
@@ -2,7 +2,7 @@
 elevator.py
 Samuel Koller
 Created: 17 October 2024
-Updated: 22 October 2024
+Updated: 23 October 2024
 
 Class for the Elevator object, which tracks the state an contents of the elevator.
 """
@@ -83,6 +83,8 @@ class Elevator:
             button (int | str | list[int , str]): The button pressed.
             priority (bool): If the button was prioritized.
         """
+        if isinstance(button, list) or isinstance(source, list):
+            raise InvalidButton()
         if isinstance(source, int):
             if source == 13 or not 1 <= source <= TOP_FLOOR:
                 raise InvalidButton()
@@ -121,6 +123,8 @@ class Elevator:
 
     def priority_update(self) -> None:
         """Called when there is an item in the priority queue, determines action to take."""
+        self.down_queue = []
+        self.up_queue = []
         if self.current_floor == self.priority_queue[0]:
             self.priority_queue.pop(0)
             self.open()
@@ -128,6 +132,8 @@ class Elevator:
             self.move(True)
         else:
             self.move(False)
+        if not self.priority_queue:
+            self.requeue_all()
 
     def up_update(self) -> None:
         """Called when the current direction of the elevator is up, determines action to take."""
@@ -375,3 +381,11 @@ class Elevator:
             self.add_up_stop(person.location)
         else:
             self.add_down_stop(person.location)
+
+    def requeue_all(self) -> None:
+        """Called after the elevator clears it's priority queue to requeue all persons in the simulation."""
+        for person in self.persons["elevator"]:
+            self.add_stop(person.destination)
+        for i in range(1, TOP_FLOOR + 1):
+            for person in self.persons.get(i, []):
+                self.add_person_stop(person)

--- a/tests/classes/test_elevator.py
+++ b/tests/classes/test_elevator.py
@@ -2,7 +2,7 @@
 test_elevator.py
 Samuel Koller
 Created: 17 October 2024
-Updated: 22 October 2024
+Updated: 23 October 2024
 
 Test Suite for the Elevator class.
 """
@@ -143,6 +143,15 @@ def test_elevator_process_invalid_request_button_types():
         test_elevator.process_request(**{"source": "elevator", "button": "up"})
     with pytest.raises(InvalidButton):
         test_elevator.process_request(**{"source": 1, "button": 3})
+
+
+def test_elevator_process_invalid_request_list_source():
+    """
+    - Tests the ability to throw an exception if a request source is a list.
+    """
+    test_elevator = Elevator()
+    with pytest.raises(InvalidButton):
+        test_elevator.process_request(**{"source": [1, 2], "button": 1})
 
 
 def test_elevator_add_passed_stops_below():
@@ -430,3 +439,31 @@ def test_elevator_switch_direction_at_end_of_queue():
     assert test_elevator.direction_up is False
     assert len(test_elevator.persons["elevator"]) == 1
     assert len(test_elevator.persons[2]) == 0
+
+
+def test_elevator_requeues_after_priority():
+    """
+    - Tests the ability to requeue all persons in the simulation once an elevator has completed it's priority queue.
+    """
+    test_elevator = Elevator()
+    test_person_elevator = Person(**{"origin": 1, "destination": 3})
+    test_person_down = Person(**{"origin": 7, "destination": 3})
+    test_elevator.add_person(test_person_elevator)
+    test_elevator.add_person(test_person_down)
+    test_elevator.update()
+
+    assert test_elevator.down_queue == [7]  # test_person_elevator going downwards to 3
+    assert test_elevator.up_queue == [3]  # test_person_elevator going upwards to 3
+
+    # Emergency close which passes floor 3
+    test_elevator.process_request(**{"source": "elevator", "button": ["close", 4]})
+    for _ in range(3):
+        test_elevator.update()
+
+    assert test_elevator.current_floor == 4
+    assert test_elevator.priority_queue == []
+    # test_person_elevator going downwards to 3
+    assert test_elevator.down_queue == [
+        7,
+        3,
+    ]

--- a/tests/classes/test_elevator.py
+++ b/tests/classes/test_elevator.py
@@ -463,7 +463,4 @@ def test_elevator_requeues_after_priority():
     assert test_elevator.current_floor == 4
     assert test_elevator.priority_queue == []
     # test_person_elevator going downwards to 3
-    assert test_elevator.down_queue == [
-        7,
-        3,
-    ]
+    assert test_elevator.down_queue == [7, 3]

--- a/tests/classes/test_elevator.py
+++ b/tests/classes/test_elevator.py
@@ -461,6 +461,6 @@ def test_elevator_requeues_after_priority():
         test_elevator.update()
 
     assert test_elevator.current_floor == 4
-    assert test_elevator.priority_queue == []
+    assert not test_elevator.priority_queue
     # test_person_elevator going downwards to 3
     assert test_elevator.down_queue == [7, 3]


### PR DESCRIPTION
# Version 1.0.0 -> 1.0.1

## Description:

Correct bug in which stops were possibly queued in the wrong direction after a priority stop (their floor was skipped to make the priority stop).

## Changes:
- Correct bug in which floors could be queued in the wrong direction following a priority stop completion.
- Extra validation for button presses.
